### PR TITLE
php7.4 and add docker.

### DIFF
--- a/application/common.php
+++ b/application/common.php
@@ -87,7 +87,7 @@ function setCurrentOrganization($data)
 function p($data, $force = false, $file = null)
 {
     is_null($file) && $file = env('runtime_path') . date('Ymd') . '.txt';
-    $str = (is_string($data) ? $data : (is_array($data) || is_object($data)) ? print_r($data, true) : var_export($data, true)) . PHP_EOL;
+    $str = (is_string($data) ? $data : ((is_array($data) || is_object($data)) ? print_r($data, true) : var_export($data, true))) . PHP_EOL;
     $force ? file_put_contents($file, $str) : file_put_contents($file, $str, FILE_APPEND);
 }
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,23 @@
+# How to use ?
+
+You need build PearProject docker image.
+
+choise php version , and `cd` to dir.
+
+```
+# build
+docker build -t pear-docker:1.0.0 .
+
+# cd to root path
+cd ../..
+
+# attach container install composer vendor
+docker run --rm -it --mount type=bind,source="$(pwd)",target=/app pear-docker:1.0.0 /bin/bash
+composer install
+exit
+
+# run your docker
+docker run --mount type=bind,source="$(pwd)",target=/app -p 1234:8081 pear-docker:1.0.0
+```
+
+Right , now visit http://127.0.0.1:1234 

--- a/docker/php72/Dockerfile
+++ b/docker/php72/Dockerfile
@@ -1,0 +1,41 @@
+FROM php:7.2-cli
+
+# change package source for aliyun
+run cp /etc/apt/sources.list /etc/apt/sources.list.bak \
+  && echo "deb http://mirrors.aliyun.com/debian buster main" > /etc/apt/sources.list \
+  && echo "deb http://mirrors.aliyun.com/debian buster-updates main" >> /etc/apt/sources.list \
+  && apt clean;
+
+# update package
+RUN apt-get update;
+
+# install php ext
+RUN apt-get install -y libzip-dev libzip4 \
+  && pecl install redis-5.2.0 \
+  && pecl install igbinary-3.1.2 \
+  && pecl install zip-1.17.2 \
+  && docker-php-ext-enable redis igbinary zip
+
+# install php ext PDO
+RUN docker-php-ext-install pdo pdo_mysql
+
+# install php gd ext
+RUN apt-get install -y libwebp-dev libjpeg-dev libpng-dev libfreetype6-dev libjpeg62-turbo-dev \
+  && docker-php-ext-configure gd --with-gd --with-webp-dir --with-jpeg-dir --with-png-dir --with-zlib-dir --with-freetype-dir \
+  && docker-php-ext-install -j$(nproc) gd
+
+# install wget
+RUN apt-get install wget -y
+
+# install composer
+RUN cd /tmp \
+  && wget https://mirrors.aliyun.com/composer/composer.phar \
+  && mv composer.phar /usr/local/bin/composer \
+  && chmod +x /usr/local/bin/composer \
+  && composer config -g repo.packagist composer https://mirrors.aliyun.com/composer/ \
+  && composer self-update \
+  && composer clear
+
+WORKDIR /app
+
+CMD ["php", "-S", "0.0.0.0:8081"]

--- a/docker/php74/Dockerfile
+++ b/docker/php74/Dockerfile
@@ -1,0 +1,42 @@
+FROM php:7.4-cli
+
+
+# change package source for aliyun
+run cp /etc/apt/sources.list /etc/apt/sources.list.bak \
+  && echo "deb http://mirrors.aliyun.com/debian buster main" > /etc/apt/sources.list \
+  && echo "deb http://mirrors.aliyun.com/debian buster-updates main" >> /etc/apt/sources.list \
+  && apt clean;
+
+# update package
+RUN apt-get update;
+
+# install php gd ext
+RUN apt-get install -y libwebp-dev libjpeg-dev libpng-dev libfreetype6-dev libjpeg62-turbo-dev\
+  && docker-php-ext-configure gd --with-freetype --with-jpeg \
+  && docker-php-ext-install -j$(nproc) gd
+
+# install php ext
+RUN apt-get install -y libzip-dev libzip4 \
+  && pecl install redis-5.2.0 \
+  && pecl install igbinary-3.1.2 \
+  && pecl install zip-1.17.2 \
+  && docker-php-ext-enable redis igbinary zip
+
+# install php ext PDO
+RUN docker-php-ext-install pdo pdo_mysql
+
+# install wget
+RUN apt-get install wget -y
+
+# install composer
+RUN cd /tmp \
+  && wget https://mirrors.aliyun.com/composer/composer.phar \
+  && mv composer.phar /usr/local/bin/composer \
+  && chmod +x /usr/local/bin/composer \
+  && composer config -g repo.packagist composer https://mirrors.aliyun.com/composer/ \
+  && composer self-update \
+  && composer clear
+
+WORKDIR /app
+
+CMD ["php", "-S", "0.0.0.0:8081"]


### PR DESCRIPTION
昨日我们团队有同学提到此项目，希望我们内部使用。

我拿来做测试部署之后发现有一些兼容问题和部署文档不太清晰的问题
例如 PHP 74 的环境下运行，有不推荐写法。

```
Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in /application/common.php
on line 90
```

官方说明是 PHP  >= 7.2.0 ，所以我用 PHP74 环境运行后很是意外，实际浏览源代码之后发现是少一对括号。

接下来我们也思考了如果在内部使用该项目，那么对应生产环境应该怎样处理。

最好的方案还是用 Docker 来部署，所以也针对该项目写了官方推荐的 PHP 72 版本和 PHP74 环境下的 DockerFile，当前的 DockerFile 还只是简单的把项目无障碍的运行起来。

一些项目的特性（WebSocket、等……）暂时还没有接触，因为我们不是太了解 ThinkPHP 这个生态。

另外提一点建议，希望把配置参数从项目代码里拆分出来。
现在都是依赖于项目内的 .php 文件，且被 Git 追踪，这样不是很利于版本升级的工作；
可以借鉴 .env .yml 的方式来处理配置参数的保存，比如 Mysql 和 Redis，且 Redis 应该支持分库的参数。

最后祝项目越来越好，加油！